### PR TITLE
노래, 광고 분류기 오류 수정

### DIFF
--- a/VisualRadio/split_module/split2.py
+++ b/VisualRadio/split_module/split2.py
@@ -236,7 +236,8 @@ def find_quiet_time(y, sr):
       lst.append(intTime)
       
   if(len(lst)==0):
-      return lst
+      return True
+  
   merged = []
   sublist = [lst[0]]  # 첫 번째 원소로 시작하는 부분 리스트 생성
   


### PR DESCRIPTION
기존에는 정적구간의 길이가 0 일 때 아래와 같은 코드로 되어있었습니다.

if(len(lst)==0):
  return lst

로 되어있었음. 당연히 빈 구간을 return했기에 false가 됩니다. find_music에서 false는 광고라는 뜻인데, 우리 의도는 정적 구간이 아예 없으면 노래라고 판단해야했기에 이 부분이 잘못되었습니다.

따라서 
if(len(lst)==0):
  return True

로 변경하였습니다.