### PR TITLE
136 refactor split2 ment

### DIFF
--- a/VisualRadio/services.py
+++ b/VisualRadio/services.py
@@ -10,7 +10,10 @@ import time
 import utils
 import wave
 from split_module.split import start_split
-from split_module.split2 import save_split, split_music
+# split2 경로가 바뀌었으므로, 수정해줌.
+from split2.split2 import save_split, split_music, SplitMent
+from split2.MrRemoverToArray import MrRemoverToArray, remove_mr_to_array
+# from split2.MrRemoverToFile import MrRemoverToFile
 import threading
 from datetime import datetime
 from datetime import timedelta
@@ -239,142 +242,12 @@ def get_segment(broadcast, name, date):
             res = wav.radio_section.replace("'", "\"")
             return json.loads(res)
         
-from spleeter.separator import Separator
-import shutil
-import numpy as np
-from natsort import natsorted
-
-# 클래스로 뺐다 (진행시간 고려해서 spleeter 돌리려고)
-class MrRemover:
-    def __init__(self):
-        self.is_running = False
-        self.is_done = False
-        self.thread = None
-        self.separator = Separator('spleeter:2stems')
-
-    def set_path(self, audio_path, tmp_mr_path):
-        self.audio_path = audio_path
-        self.tmp_mr_path = tmp_mr_path
-
-    def start(self):
-        self.is_running = True
-        self.is_done = False
-        self.start_time = time.time()  # 작업 시작시간 기록
-        self.thread = threading.Thread(target=self.background_process)
-        self.thread.start()
-
-    def stop(self):
-        self.is_running = False
-        if self.thread:
-            self.thread.join(timeout=0.1)
-
-    def background_process(self):
-        while self.is_running:
-            self.separator.separate_to_file(self.audio_path, self.tmp_mr_path) # 오래 걸리는 작업
-            self.is_running = False
-            self.is_done = True
-            return
-
-
-from joblib import Parallel, delayed
-def cutting_audio(broadcast, name, date, duration, audio_holder):
-    tmp_path = utils.get_path(broadcast, name, date)+"tmp"
-    # splited_path = utils.hash_splited_path(broadcast, name, date)
-    # section_wav_origin_names = natsorted(utils.ourlistdir(splited_path))
-
-    # 작업에 사용할 인자 리스트 준비
-    splits = audio_holder.splits
-    for split in splits:
-        split_name = split[0]
-        audio = split[1]
-        sr = audio_holder.sr
-
-        idx = 0
-        logger.debug(f"[mr제거] {int(duration/60)}분 파일로 쪼개 저장중: {split_name}")
-        if(len(audio) > duration*sr):
-            for i in range(0, len(audio)-duration*sr, duration*sr):
-                seg_audio = audio[i : i+duration*sr]
-                save_name = f"{tmp_path}/{split_name}-{str(idx)}.wav"
-                sf.write(save_name, seg_audio, sr)
-                idx+= 1
-            save_name = f"{tmp_path}/{split_name}-{str(idx)}.wav"
-            sf.write(save_name, audio[i+duration*sr:len(audio)], sr)
-        else:
-            save_name = f"{tmp_path}/{split_name}-{str(idx)}.wav"
-            sf.write(save_name, audio, sr)
         
-    return
+# mr제거에 관한 부분을 클래스로 뺏으므로, 이 부분은 단순히 MrRemoverToArray를 호출하게만 했습니다.
+def remove_mr(audio_holder):
+    remove_mr_to_array(audio_holder)
 
-def remove_mr(broadcast, name, date, audio_holder, duration=int(600/2)):
-    logger.debug("[mr제거] 시작")
-    tmp_path = utils.get_path(broadcast, name, date)+"tmp"
-    if not os.path.exists(tmp_path):
-            os.makedirs(tmp_path)
-
-    # 오디오 커팅
-    cutting_audio(broadcast, name, date, duration, audio_holder)
-
-    #--------------------------------------------------------------
-    # MR제거
-    mr_path = utils.mr_splited_path(broadcast, name, date)
-    tmp_mr_path = utils.tmp_mr_splited_path(broadcast, name, date)
-    seg_list = utils.ourlistdir(tmp_path)
-    mr_remover = MrRemover()
-    for seg_mr in seg_list:
-        logger.debug(f"[mr제거] {seg_mr} mr 제거중..")
-        audio_path = os.path.join(tmp_path, seg_mr)
-
-        mr_remover.set_path(audio_path, tmp_mr_path)
-        mr_remover.start()
-        try:
-            while True:
-                time.sleep(10)
-                gc.collect()
-                # 작업이 너무 오래 걸릴 경우 재시작 & 초기화
-                # 설정해둔 시간값: duration / 2 : 쪼갠파일이 맥시멈 10분이면, 5분안에 처리되도록 의도
-                if mr_remover.is_running and not mr_remover.is_done:
-                    elapsed_time = time.time() - mr_remover.start_time
-                    if elapsed_time > int(duration/3): 
-                        logger.debug(f"[mr제거] {seg_mr} 오래 걸려서 재시작")
-                        mr_remover.stop()
-                        mr_remover = None
-                        mr_remover = MrRemover()
-                        mr_remover.set_path(audio_path, tmp_mr_path)
-                        mr_remover.start()
-                        gc.collect()
-                elif not mr_remover.is_running and mr_remover.is_done:
-                    break
-        except:
-            print("에러")
-
-    mr_remover.stop()
-    mr_remover = None
-    gc.collect()
-    #--------------------------------------------------------------
-
-    # 디렉토리 자체 삭제
-    shutil.rmtree(tmp_path)
-    
-    section_wav__names = natsorted(utils.ourlistdir(tmp_mr_path))
-    for fname in section_wav__names:
-        rname = fname.split("-")[0]
-        logger.debug(f"[mr제거] 오디오 합치는 중.. {fname}")
-        vocals = f"{tmp_mr_path}{fname}/vocals.wav"
-        x, sr = librosa.load(vocals)
-        for a in section_wav__names:
-            if(fname == a):
-                continue
-            r2name = a.split("-")[0]
-            if(r2name == rname):
-                vocals2 = f"{tmp_mr_path}{a}/vocals.wav"
-                y, sr = librosa.load(vocals2)
-                x = np.concatenate((x, y),axis=0)
-        direct = f"{mr_path}/{rname}.wav"
-        if not os.path.exists(direct):
-            sf.write(direct, x, sr)
-    
-    return
-    
+import numpy as np
 from natsort import natsorted 
 
 def split_cnn(broadcast, name, date, audio_holder):

--- a/VisualRadio/split2/MrRemoverToArray.py
+++ b/VisualRadio/split2/MrRemoverToArray.py
@@ -1,0 +1,164 @@
+from spleeter.separator import Separator
+import time
+import numpy as np
+from joblib import Parallel, delayed
+from VisualRadio import CreateLogger
+import threading
+import gc
+
+
+class MrRemoverToArray:
+    def __init__(self):
+        self.is_running = False
+        self.is_done = False
+        self.thread = None
+        self.separator = Separator('spleeter:2stems')
+        self.split_mrs = []
+        self.name_list = []
+        self.wav = None
+    
+    def set_name(self, name):
+        self.name = name
+        self.name_list.append(name)
+
+    def start(self):
+        self.is_running = True
+        self.is_done = False
+        self.start_time = time.time()  # 작업 시작시간 기록
+        self.thread = threading.Thread(target=self.background_process)
+        self.thread.start()
+
+    def stop(self):
+        self.is_running = False
+        if self.thread:
+            self.thread.join(timeout=0.1)
+
+    def background_process(self):
+        while self.is_running:
+            y = self.separator.separate(self.wav) # 오래 걸리는 작업
+            vocal = y['vocals']
+            mono_data = np.mean(vocal, axis=1)
+            self.split_mrs.append([self.name, mono_data])
+            self.is_running = False
+            self.is_done = True
+            
+            
+def cutting_audio(duration, audio_holder):
+
+    # 작업에 사용할 인자 리스트 준비
+    splits = audio_holder.splits
+    for split in splits:
+        split_name = split[0]
+        audio = split[1]
+        logger.debug(f"{split_name}의 audio.shape는 {audio.shape}입니다.")
+        sr = audio_holder.sr
+
+        idx = 0
+        logger.debug(f"[mr제거] {int(duration/60)}분 파일로 쪼개 저장중: {split_name}")
+        seg = False
+        if(len(audio) > duration*sr):
+            seg = True
+            for i in range(0, len(audio)-duration*sr, duration*sr):
+                seg_audio = audio[i : i+duration*sr]
+                save_name = f"{split_name}-{str(idx)}.wav"
+                audio_holder.tmps.append([save_name, seg_audio])
+                logger.debug(f"[cutting audio] {save_name}의 seg_audio.shape : {seg_audio.shape}")
+                idx+= 1
+        save_name = f"{split_name}-{str(idx)}.wav"
+        
+        if not seg:
+            audio_holder.tmps.append([save_name, audio])
+            logger.debug(f"[cutting audio] save_name : {save_name}")
+            logger.debug(f"[cutting audio] seg_audio : {audio}")
+            logger.debug(f"[cutting audio] seg_audio.shape : {audio.shape}")
+        else:
+            seg_audio = audio[i+duration*sr:len(audio)]
+            audio_holder.tmps.append([save_name, seg_audio])
+            logger.debug(f"[cutting audio] save_name : {save_name}")
+            logger.debug(f"[cutting audio] seg_audio : {seg_audio}")
+            logger.debug(f"[cutting audio] seg_audio.shape : {seg_audio.shape}")
+        
+       
+        
+        
+    return
+
+logger = CreateLogger("services")
+
+
+def remove_mr_to_array(audio_holder, duration=int(600/2)):
+    logger.debug("[mr제거] 시작")
+
+    # 오디오 커팅
+    cutting_audio(duration, audio_holder)
+
+    #--------------------------------------------------------------
+    # MR제거
+    
+    seg_list = audio_holder.tmps
+
+    mr_remover = MrRemoverToArray()
+    for seg_mr in seg_list:
+        logger.debug(f"[mr제거] {seg_mr[0]} mr 제거중..")
+
+        mr_remover.set_name(seg_mr[0])
+        wav_reshape = np.reshape(seg_mr[1], (-1, 1))
+        mr_remover.wav = wav_reshape
+        mr_remover.start()
+        try:
+            while True:
+                time.sleep(10)
+                gc.collect()
+                # 작업이 너무 오래 걸릴 경우 재시작 & 초기화
+                # 설정해둔 시간값: duration / 2 : 쪼갠파일이 맥시멈 10분이면, 5분안에 처리되도록 의도
+                if mr_remover.is_running and not mr_remover.is_done:
+                    elapsed_time = time.time() - mr_remover.start_time
+                    if elapsed_time > int(duration/3): 
+                        logger.debug(f"[mr제거] {seg_mr[0]} 오래 걸려서 재시작")
+                        mr_remover.stop()
+                        mr_remover = None
+                        mr_remover = MrRemoverToArray()
+                        mr_remover.set_name(seg_mr[0])
+                        mr_remover.start()
+                        gc.collect()
+                elif not mr_remover.is_running and mr_remover.is_done:
+                    break
+        except:
+            print("에러")
+
+    mr_remover.stop()
+    
+    
+    #--------------------------------------------------------------
+
+    section_wav__names = mr_remover.split_mrs
+    name_list = []
+
+    logger.debug("여기부터 시작")
+    for fname, wav in section_wav__names:
+        rname = fname.split("-")[0]
+        if rname+".wav" in name_list:
+            continue
+        logger.debug(f"[mr제거] 오디오 합치는 중.. {fname}")
+        x = wav
+        for name, other_wav in section_wav__names:
+            if(fname == name):
+                continue
+            r2name = name.split("-")[0]
+            if(r2name == rname):
+                logger.debug(f"{fname}과 {name}이 같습니다.")
+                logger.debug(f"other_wav.shape : {other_wav.shape}")
+                x = np.concatenate((x, other_wav), axis=0)
+        direct = f"{rname}.wav"
+        logger.debug(f"[mr제거] {direct}의 길이는 {x.shape}이고 sr은 {audio_holder.sr}입니다.")
+        audio_holder.sum_mrs.append([direct, x])
+        name_list.append(direct)
+    
+    # print(audio_holder.sum_mrs)
+    logger.debug("끝, 이 전에 긴 문장이 나와야해여")
+    logger.debug(f"audio_holder.sum_mrs : {audio_holder.sum_mrs}")
+    # print(mr_remover.name_list)
+    # audio_holder.sr = int(audio_holder.sr/2)
+    mr_remover = None
+    gc.collect()
+    return

--- a/VisualRadio/split2/split2.py
+++ b/VisualRadio/split2/split2.py
@@ -21,6 +21,7 @@ class SplitMent:
     def set_model(self, model_path): # 인자로 모델 경로를 받은 후,
         model = models.resnet18(pretrained=True)
 
+        # 분류할 클래스의 수
         num_classes = 2 
         num_ftrs = model.fc.in_features
         model.fc = nn.Linear(num_ftrs, num_classes)

--- a/VisualRadio/split_module/split.py
+++ b/VisualRadio/split_module/split.py
@@ -41,8 +41,8 @@ import librosa
 import soundfile as sf
 def start_split(path, program_name, save_path, audio_holder):
     song_info, time = split_about(path, program_name)
-    # audio = AudioSegment.from_file(path).set_channels(1).set_frame_rate(settings.SAMPLE_RATE)
-    audio, sr = librosa.load(path, sr=None)
+    # 이제부터 sr을 22050으로 고정적으로 바꿔줍니다. 이는 PR에 자세히 작성하겠습니다.
+    audio, sr = librosa.load(path, sr=22050)
     holder_list = []
     for i in range(len(time)):
         start = int(time[i] * sr)


### PR DESCRIPTION
# Motivation
멘트 분류기에서 파일 작성을 진행하지 않도록 바꿨습니다.

# How to
우선 각 메서드에 대해서, 불필요하다고 판단한 인자들을 지워줬습니다. 이는, audioHolder의 역할이 커졌고, 모든 오디오 전처리 과정에 관여하고 있기 때문입니다. 따라서 위 사항에 대해서는 아래에 언급하지 않습니다.

### refactor : split2_ment
splitMent라는 클래스를 구현하였습니다. 이 클래스는 멘트를 분류하는 모델을 미리 로드하여 필드에 갖고 있습니다. 따라서, split_ment를 할 때마다 로드하는 번거로움을 덜어주었습니다.

또한 split2에 대한 디렉토리를 따로 만들어주었습니다.

필요없는 로그들이 보일텐데, 이는 다른 커밋 기록에서 삭제해주었습니다.

### refactor: mr_remove
split2에 대한 모듈을 만들어 주었기 때문에, import하는 부분에서 경로 설정을 변경해주었습니다. 
mr_remove 또한 split2의 한 과정으로 판단하고 split2 모듈로 옮겨주었습니다. 이에 따라서, service.py에 있던 remove_mr 관련 코드들이 삭제되었습니다.

MrRemoveToArray 클래스를 구현했습니다. remove_mr의 과정에서 5분 단위로 잘라서 spleeter를 거쳐 나온 파일들을 audioHolder에 저장합니다.

### refactor: split_cnn
기존 split_cnn은 mr 제거된 음성을 로드하여 처리하였습니다. 이제 저희는 음성을 write하지 않으므로, audioHolder에서 꺼내 split_cnn 해주는 코드로 변경하였습니다.

### fix: stable sr
기존에 sec_n.wav의 sr은 44100입니다. 여기서 spleeter를 거치면 22050으로 되는데, 이러한 부분에서의 오디오 전처리가 말썽이었습니다. 따라서, sec_n.wav를 로드할 때부터 sr을 22050으로 설정해주어 진행해주었습니다. 이에 따라, 오디오 전처리 과정에서의 오류를 디버깅하였습니다.

### refactor: remove comment for clean code
오디오 전처리를 실행하여 확인하기 위해 달았던 로그들을 수정하고, 불필요한 주석을 삭제하였습니다.

# Issue Number and Link
#136 

# To Reviewers
코드 양이 많습니다. 또한, 오디오 전처리를 제대로 이해하지 않으면 구조나 순서를 파악하기 어렵습니다. 이 참에 전체적인 처리 과정에 대해서 완벽하게 이해한다고 생각하고 읽어주시면 됩니다! 혹시 읽다가 모르는 부분이나 헷갈리는 부분들은, 코멘트 날려주시거나 연락 주시면 답변해드릴게요!!

close #136 