### PR TITLE
fix: mr audio length mismatch problem

### DIFF
--- a/VisualRadio/split2/MrRemoverToArray.py
+++ b/VisualRadio/split2/MrRemoverToArray.py
@@ -27,6 +27,7 @@ class MrRemoverToArray:
 
     def stop(self):
         self.is_running = False
+        self.separator = None
         if self.thread:
             self.thread.join(timeout=0.1)
 
@@ -111,27 +112,21 @@ def remove_mr_to_array(audio_holder, duration=int(600/2)):
     mr_remover.input_mrs = mr_targets
     mr_remover.start()
 
-    # 기존의 try-except 구문은 지워두겠습니다.
-
-
+    # 기존의 try-except 구문은 간소화해두겠습니다.
+    # 필요성 불필요성은 차선으로 두겠습니다.
+    try:
+        while True:
+            time.sleep(5) # 5초마다 종료 체크
+            if not mr_remover.is_running and mr_remover.is_done:
+                break
+    except:
+        print("에러")
+    mr_remover.stop()
     #--------------------------------------------------------------
-
+    
     section_wav__names = mr_remover.split_mrs
     name_list = []
 
-    logger.debug(f"mr제거 전 input->mr제거 전후 개수 확인")
-    logger.debug(f"{len(mr_remover.split_mrs)}")
-    logger.debug(f"{len(mr_remover.input_mrs)}")
-
-    logger.debug(f"각 sec.wav별 길이 비교")
-    sm = mr_remover.split_mrs
-    im = mr_remover.input_mrs
-    for i in range(len(section_wav__names)):
-        logger.debug(f"mr이후{sm[i][0]} vs mr이전{im[i][0]}")
-        logger.debug(f"{len(sm[i][1])} vs {len(im[i][1])}")
-
-    
-    logger.debug("여기부터 시작")
     for fname, wav in section_wav__names:
         rname = fname.split("-")[0]
         if rname+".wav" in name_list:

--- a/VisualRadio/split2/MrRemoverToArray.py
+++ b/VisualRadio/split2/MrRemoverToArray.py
@@ -14,17 +14,14 @@ class MrRemoverToArray:
         self.thread = None
         self.separator = Separator('spleeter:2stems')
         self.split_mrs = []
-        self.name_list = []
-        self.wav = None
+        self.input_mrs = []
     
-    def set_name(self, name):
-        self.name = name
-        self.name_list.append(name)
-
     def start(self):
+        # update status
         self.is_running = True
         self.is_done = False
-        self.start_time = time.time()  # 작업 시작시간 기록
+        self.start_time = time.time()
+        # start theadings
         self.thread = threading.Thread(target=self.background_process)
         self.thread.start()
 
@@ -35,12 +32,22 @@ class MrRemoverToArray:
 
     def background_process(self):
         while self.is_running:
-            y = self.separator.separate(self.wav) # 오래 걸리는 작업
-            vocal = y['vocals']
-            mono_data = np.mean(vocal, axis=1)
-            self.split_mrs.append([self.name, mono_data])
+            # input_mrs
+            for target in self.input_mrs:
+                name = target[0]
+                audio = target[1]
+                logger.debug(f"[mr제거] {name}.. 오디오 길이 {len(audio)}")
+                y = self.separator.separate(audio) # 오래 걸리는 작업
+                vocal = y['vocals'] 
+                logger.debug(f"[mr제거] {name}.. 추출된 vocals 길이 {len(vocal)}")
+                mono_data = np.mean(vocal, axis=1)
+                logger.debug(f"[mr제거] {name}.. 만들어진 mono_data 길이 {len(mono_data)}")
+                self.split_mrs.append([name, mono_data])
+                logger.debug(f"[mr제거] 완료되었습니다. spleeter객체를 초기화해볼게요!") # mr제거 결과가 하나씩 밀리는 문제를 객체초기화로 해결!
+                self.separator = Separator('spleeter:2stems')
             self.is_running = False
             self.is_done = True
+            return
             
             
 def cutting_audio(duration, audio_holder):
@@ -78,13 +85,9 @@ def cutting_audio(duration, audio_holder):
             logger.debug(f"[cutting audio] seg_audio : {seg_audio}")
             logger.debug(f"[cutting audio] seg_audio.shape : {seg_audio.shape}")
         
-       
-        
-        
     return
 
 logger = CreateLogger("services")
-
 
 def remove_mr_to_array(audio_holder, duration=int(600/2)):
     logger.debug("[mr제거] 시작")
@@ -92,48 +95,42 @@ def remove_mr_to_array(audio_holder, duration=int(600/2)):
     # 오디오 커팅
     cutting_audio(duration, audio_holder)
 
-    #--------------------------------------------------------------
-    # MR제거
-    
+    # MR 제거--------------------------------------------------------------
+    # bring seg from audio holder
     seg_list = audio_holder.tmps
-
     mr_remover = MrRemoverToArray()
+
+    # target reshape
+    mr_targets = []
     for seg_mr in seg_list:
-        logger.debug(f"[mr제거] {seg_mr[0]} mr 제거중..")
-
-        mr_remover.set_name(seg_mr[0])
+        seg_name = seg_mr[0]
         wav_reshape = np.reshape(seg_mr[1], (-1, 1))
-        mr_remover.wav = wav_reshape
-        mr_remover.start()
-        try:
-            while True:
-                time.sleep(10)
-                gc.collect()
-                # 작업이 너무 오래 걸릴 경우 재시작 & 초기화
-                # 설정해둔 시간값: duration / 2 : 쪼갠파일이 맥시멈 10분이면, 5분안에 처리되도록 의도
-                if mr_remover.is_running and not mr_remover.is_done:
-                    elapsed_time = time.time() - mr_remover.start_time
-                    if elapsed_time > int(duration/3): 
-                        logger.debug(f"[mr제거] {seg_mr[0]} 오래 걸려서 재시작")
-                        mr_remover.stop()
-                        mr_remover = None
-                        mr_remover = MrRemoverToArray()
-                        mr_remover.set_name(seg_mr[0])
-                        mr_remover.start()
-                        gc.collect()
-                elif not mr_remover.is_running and mr_remover.is_done:
-                    break
-        except:
-            print("에러")
+        mr_targets.append([seg_name, wav_reshape])
 
-    mr_remover.stop()
-    
-    
+    # removing process in MrRemover!
+    mr_remover.input_mrs = mr_targets
+    mr_remover.start()
+
+    # 기존의 try-except 구문은 지워두겠습니다.
+
+
     #--------------------------------------------------------------
 
     section_wav__names = mr_remover.split_mrs
     name_list = []
 
+    logger.debug(f"mr제거 전 input->mr제거 전후 개수 확인")
+    logger.debug(f"{len(mr_remover.split_mrs)}")
+    logger.debug(f"{len(mr_remover.input_mrs)}")
+
+    logger.debug(f"각 sec.wav별 길이 비교")
+    sm = mr_remover.split_mrs
+    im = mr_remover.input_mrs
+    for i in range(len(section_wav__names)):
+        logger.debug(f"mr이후{sm[i][0]} vs mr이전{im[i][0]}")
+        logger.debug(f"{len(sm[i][1])} vs {len(im[i][1])}")
+
+    
     logger.debug("여기부터 시작")
     for fname, wav in section_wav__names:
         rname = fname.split("-")[0]


### PR DESCRIPTION
# Motivation
mr제거 전후 audio length 불일치 문제

# How to

문제상황: 연속된 mr제거시, 현재 오디오배열이 아닌 이전 오디오배열이 반영되는 문제를 발견했습니다. 그래서 처리가 하나씩 밀립니다. 그래서 audio length가 맞지 않는 것이었습니다. 

해결완료: MrRemoverToArray 객체가 가지는 spleeter객체를 매번 초기화해서 이전 이력이 남을 가능성을 아예 차단했습니다.

# Issue Number and Link
#139 