### PR TITLE
feat: split2 music

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ instance/*
 __pycache__/
 
 # model
-VisualRadio/split_module/split_good_model.h5
+VisualRadio/split2/resnet_model_test1.pth
+VisualRadio/split2/bert-kor-base.pth
 
 # C extensions
 *.so

--- a/VisualRadio/Dockerfile
+++ b/VisualRadio/Dockerfile
@@ -48,6 +48,7 @@ RUN pip uninstall numpy -y
 RUN pip install numpy --upgrade
 RUN pip install numba==0.55.2
 RUN pip install gensim==3.4.0
+RUN pip install transformers
 
 
 

--- a/VisualRadio/route.py
+++ b/VisualRadio/route.py
@@ -37,6 +37,7 @@ class AudioHolderToArray:
         self.sr = 0
         self.sum = []
         self.sum_mrs = [] # 5분 단위로 쪼갠 음성을 합쳐줍니다.
+        self.jsons = [] # 가장 먼저 진행되는 json들을 넣어줍니다. 이 때, time 속성은 초단위!!
     
     def set_audio_info(self):
         logger.debug("[AudioHolderToArray] setting..")

--- a/VisualRadio/settings.py
+++ b/VisualRadio/settings.py
@@ -54,8 +54,12 @@ NUM_WORKERS = 24
 
 
 # CNN 모델 path
-# MODEL_PATH = './VisualRadio/split_module/split_good_model.h5'
-MODEL_PATH = './VisualRadio/split_module/resnet_model_test1.pth'
+# MENT_MODEL_PATH = './VisualRadio/split_module/split_good_model.h5'
+MENT_MODEL_PATH = './VisualRadio/split2/resnet_model_test1.pth'
+
+MUSIC_MODEL_PATH = './VisualRadio/split2/bert-kor-base.pth'
+
+CHECKPOINT_NAME = 'kykim/bert-kor-base'
 
 # radio_storage까지의 경로
 STORAGE_PATH = 'VisualRadio/radio_storage'

--- a/VisualRadio/split2/split2Ment.py
+++ b/VisualRadio/split2/split2Ment.py
@@ -148,6 +148,55 @@ def drop_doubt_ad(time_range, sec):
             res.append(i)
     return res
 
+# 가장 먼저 진행한 stt의 구간에 맞게 멘트 구간을 조정합니다.
+def adjust_json_data(json_data, intervals):
+    adjusted_data = []
+    
+    for start, end in intervals:
+        start_time = None
+        end_time = None
+        past_start_time = None
+        for item in json_data:
+            json_start_time = item['time']
+            
+            # 시작시간을 stt가 나눈 시작 시간으로 매핑합니다.
+            if start_time is None and past_start_time is not None and past_start_time <= start <= json_start_time:
+                start_time = past_start_time
+                
+            # 종료시간을 stt가 나눈 이전 시작 시간으로 매핑합니다.
+            if end_time is None and past_start_time is not None and past_start_time <= end <= json_start_time:
+                end_time = json_start_time
+            
+            # start와 end가 정해지면 append하고 반복을 종료합니다.
+            if start_time is not None and end_time is not None:
+                adjusted_data.append([start_time, end_time])
+                break
+                
+            past_start_time = json_start_time
+
+    return adjust_intervals(adjusted_data) # 마지막으로 구간 다듬기까지!
+
+def adjust_intervals(intervals):
+    # 입력된 구간을 시작 시간을 기준으로 정렬
+    intervals.sort(key=lambda x: x[0])
+
+    adjusted_intervals = []
+
+    current_interval = intervals[0]
+    for interval in intervals[1:]:
+        if interval[0] <= current_interval[1]:
+            # 현재 구간과 다음 구간이 겹칠 경우, 더 큰 범위로 조정
+            current_interval[1] = max(current_interval[1], interval[1])
+        else:
+            # 겹치지 않을 경우, 현재 구간을 결과에 추가하고 다음 구간으로 이동
+            adjusted_intervals.append(current_interval)
+            current_interval = interval
+
+    # 마지막 구간 추가
+    adjusted_intervals.append(current_interval)
+
+    return adjusted_intervals
+
 # 여기에 광고 구간을 쳐내는 로직이 들어가면 딱인데...
 def extract_not_ment(ment_range, length):
     if len(ment_range) == 0:
@@ -182,14 +231,15 @@ def merge_and_sort_ranges(range_list1, range_list2):
     sorted_ranges = sorted(merged_ranges, key=lambda x: x[0])
     return sorted_ranges
 
-def save_split(model_path, audio, sr, wav_name, split_ment): # 섹션마다의 길이를 누적해서 더해줘야함!
+def save_split(audio, sr, split_ment, json_data): # 섹션마다의 길이를 누적해서 더해줘야함!
     ment_range = find_voice(audio, sr)
     real_ment = model_predict(audio, sr, ment_range, split_ment)
     real_ment_time = divide_all_elements(real_ment, sr)
     merged_real_ment_time = merge_intervals(real_ment_time, 10)
     ment_without_ad = drop_doubt_ad(merged_real_ment_time, 10) # 20초로 하는게 좋아보임!
-    not_ment = extract_not_ment(ment_without_ad, len(audio)/sr)
-    all_range = merge_and_sort_ranges(ment_without_ad, not_ment)
+    adjust_ment = adjust_json_data(json_data, ment_without_ad)
+    not_ment = extract_not_ment(adjust_ment, len(audio)/sr)
+    all_range = merge_and_sort_ranges(adjust_ment, not_ment)
 
 
     logger.debug(f"not_ment : {not_ment}")
@@ -197,86 +247,4 @@ def save_split(model_path, audio, sr, wav_name, split_ment): # 섹션마다의 �
     for idx, segment in enumerate(ment_without_ad):
         logger.debug(f"Segment {idx} ★")
         
-    return ment_without_ad, all_range, not_ment # content_range
-
-
-
-def find_quiet_time(y, sr):
-  # 주어진 스펙트로그램 데이터
-  y = np.abs(librosa.stft(y))
-  spec_data = librosa.amplitude_to_db(y, ref=np.max)
-  
-  # 소리가 거의 없는 구간을 저장할 리스트
-  quiet_segments = []
-
-  # 스펙트로그램에서 어두운 영역을 탐색
-  for time_frame, amplitude_frame in enumerate(spec_data.T):
-      if np.max(amplitude_frame) <= -60:  # 진폭이 -40 dB 미만인 영역을 소리가 거의 없는 구간으로 간주
-          quiet_segments.append(time_frame)
-
-  # 프레임 간격 계산
-  hop_length = 512  # STFT에서 사용된 hop length
-  frame_interval = hop_length / sr  # 프레임 간격 (초)
-
-  # quiet_segments에 저장된 값으로부터 시간을 계산
-  quiet_segments_time = [frame_num * frame_interval for frame_num in quiet_segments]
-
-  lst = []
-  for time in quiet_segments_time:
-    intTime = int(time)
-    contains = False
-    for i in lst:
-      if(i == intTime):
-        contains = True
-    if(not contains):
-      lst.append(intTime)
-      
-  if(len(lst)==0):
-      return True
-  
-  merged = []
-  sublist = [lst[0]]  # 첫 번째 원소로 시작하는 부분 리스트 생성
-  
-  for i in range(1, len(lst)):
-      diff = lst[i] - lst[i - 1]  # 현재 원소와 이전 원소 사이의 차이 계산
-      
-      if diff <= 9:
-          sublist.append(lst[i])  # 차이가 9 이하이면 부분 리스트에 추가
-      else:
-          if len(sublist) > 1:
-              merged.append(sublist)  # 차이가 9 이상이면 현재 부분 리스트를 합치고 새로운 부분 리스트 생성
-          else:
-              merged.append([sublist[0]])
-          sublist = [lst[i]]
-  
-  if len(sublist) > 1:
-      merged.append(sublist)  # 마지막 부분 리스트를 추가
-  else:
-      merged.append([sublist[0]])
-  
-  res = [sublist[0] if len(sublist) == 1 else sublist[0] for sublist in merged]
-      
-  x = res[0]
-  for i in range(1, len(res)):
-      y = res[i]
-      if(is_difference_valid(x, y)):
-          return False
-      x = y
-  return True
-
-def is_difference_valid(x, y):
-    diff = abs(x - y)
-    return diff % 20 == 1 or diff % 20 == 19 or diff % 20 == 0
-
-def split_music(y, sr, not_ment):
-    music_lst = []
-
-    for ran in not_ment:
-        start = ran[0]
-        end = ran[1]
-
-        seg = y[int(start*sr):int(end*sr)]
-
-        if(find_quiet_time(seg, sr)):
-            music_lst.append(ran)
-    return music_lst
+    return adjust_ment, all_range, not_ment # content_range

--- a/VisualRadio/split2/split2Music.py
+++ b/VisualRadio/split2/split2Music.py
@@ -1,0 +1,164 @@
+import numpy as np
+import librosa
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import BertModel
+from transformers import BertTokenizerFast
+import settings as settings
+
+# 로거
+from VisualRadio import CreateLogger
+logger = CreateLogger("우리가1등(^o^)b")
+
+
+class CustomPredictor():
+    def __init__(self, model, tokenizer, device):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+        
+    def predict(self, sentence):
+        # 토큰화 처리
+        tokens = self.tokenizer(
+            sentence,                # 1개 문장 
+            return_tensors='pt',     # 텐서로 반환
+            truncation=True,         # 잘라내기 적용
+            padding='max_length',    # 패딩 적용
+            add_special_tokens=True  # 스페셜 토큰 적용
+        )
+        tokens.to(self.device)
+        prediction = self.model(**tokens)
+        prediction = F.softmax(prediction, dim=1)
+        output = prediction.argmax(dim=1).item()
+        return output
+    
+class CustomBertModel(nn.Module):
+    def __init__(self, bert_pretrained, dropout_rate=0.5):
+        # 부모클래스 초기화
+        super(CustomBertModel, self).__init__()
+        # 사전학습 모델 지정
+        self.bert = BertModel.from_pretrained(bert_pretrained)
+        # dropout 설정
+        self.dr = nn.Dropout(p=dropout_rate)
+        # 최종 출력층 정의
+        self.fc = nn.Linear(768, 2)
+    
+    def forward(self, input_ids, attention_mask, token_type_ids):
+        # 입력을 pre-trained bert model 로 대입
+        output = self.bert(input_ids=input_ids, attention_mask=attention_mask, token_type_ids=token_type_ids)
+        # 결과의 last_hidden_state 가져옴
+        last_hidden_state = output['last_hidden_state']
+        # last_hidden_state[:, 0, :]는 [CLS] 토큰을 가져옴
+        x = self.dr(last_hidden_state[:, 0, :])
+        # FC 을 거쳐 최종 출력
+        x = self.fc(x)
+        return x
+    
+def split_music_new(json_data, not_ment):
+    device = torch.device('cuda:1' if torch.cuda.is_available() else 'cpu')
+
+    model_path = settings.MUSIC_MODEL_PATH
+    CHECKPOINT_NAME = settings.CHECKPOINT_NAME
+    bert = CustomBertModel(CHECKPOINT_NAME)
+    bert.load_state_dict(torch.load(model_path))
+    
+    tokenizer = BertTokenizerFast.from_pretrained(CHECKPOINT_NAME)
+    
+    # CustomPredictor 인스턴스를 생성합니다.
+    predictor = CustomPredictor(bert, tokenizer, device)
+
+    music_list = []
+    for start, end in not_ment:
+        music_tmp_list = []
+        for item in json_data:
+            json_start_time = item['time']
+            
+            if(start <= json_start_time < end):
+                output = predictor.predict(item['txt'])
+                music_tmp_list.append(output)
+        if(np.mean(music_tmp_list) < 0.5):
+            music_list.append([start, end])
+            
+    return music_list
+
+def find_quiet_time(y, sr):
+  # 주어진 스펙트로그램 데이터
+  y = np.abs(librosa.stft(y))
+  spec_data = librosa.amplitude_to_db(y, ref=np.max)
+  
+  # 소리가 거의 없는 구간을 저장할 리스트
+  quiet_segments = []
+
+  # 스펙트로그램에서 어두운 영역을 탐색
+  for time_frame, amplitude_frame in enumerate(spec_data.T):
+      if np.max(amplitude_frame) <= -60:  # 진폭이 -40 dB 미만인 영역을 소리가 거의 없는 구간으로 간주
+          quiet_segments.append(time_frame)
+
+  # 프레임 간격 계산
+  hop_length = 512  # STFT에서 사용된 hop length
+  frame_interval = hop_length / sr  # 프레임 간격 (초)
+
+  # quiet_segments에 저장된 값으로부터 시간을 계산
+  quiet_segments_time = [frame_num * frame_interval for frame_num in quiet_segments]
+
+  lst = []
+  for time in quiet_segments_time:
+    intTime = int(time)
+    contains = False
+    for i in lst:
+      if(i == intTime):
+        contains = True
+    if(not contains):
+      lst.append(intTime)
+      
+  if(len(lst)==0):
+      return True
+  
+  merged = []
+  sublist = [lst[0]]  # 첫 번째 원소로 시작하는 부분 리스트 생성
+  
+  for i in range(1, len(lst)):
+      diff = lst[i] - lst[i - 1]  # 현재 원소와 이전 원소 사이의 차이 계산
+      
+      if diff <= 9:
+          sublist.append(lst[i])  # 차이가 9 이하이면 부분 리스트에 추가
+      else:
+          if len(sublist) > 1:
+              merged.append(sublist)  # 차이가 9 이상이면 현재 부분 리스트를 합치고 새로운 부분 리스트 생성
+          else:
+              merged.append([sublist[0]])
+          sublist = [lst[i]]
+  
+  if len(sublist) > 1:
+      merged.append(sublist)  # 마지막 부분 리스트를 추가
+  else:
+      merged.append([sublist[0]])
+  
+  res = [sublist[0] if len(sublist) == 1 else sublist[0] for sublist in merged]
+      
+  x = res[0]
+  for i in range(1, len(res)):
+      y = res[i]
+      if(is_difference_valid(x, y)):
+          return False
+      x = y
+  return True
+
+def is_difference_valid(x, y):
+    diff = abs(x - y)
+    return diff % 20 == 1 or diff % 20 == 19 or diff % 20 == 0
+
+def split_music_origin(y, sr, not_ment):
+    music_lst = []
+
+    for ran in not_ment:
+        start = ran[0]
+        end = ran[1]
+
+        seg = y[int(start*sr):int(end*sr)]
+
+        if(find_quiet_time(seg, sr)):
+            music_lst.append(ran)
+    return music_lst
+


### PR DESCRIPTION
# Motivation
텍스트 기반 노래/광고 분류기 제작

# How to

### refactor: split2_ment
기존에는 split2 모듈에 mr remove 파일만 존재하였습니다. 이에, split2와 관련된 부분들을 모듈화하여 split2 모듈에 옮겼습니다. 
-> 이에 따른 split2_ment,와 split2_music의 import 등의 내용들을 수정하였습니다.

또한 split_cnn에서 불필요한 인자들이 있었습니다. 해당 인자들은 사용하지 않으므로 제거하였습니다.

+ 이제 stt가 우선적으로 실행됨에 따라서, 조금 멘트 분류기에 변화가 생겼습니다. 이제 멘트 구간은 stt에서 잘려진 구간들과 일치하게 됩니다. 자세한 것은 노션에 따로 적어두겠습니다.



### upgrade: split2_music ( 커밋 메세지 실수했습니당 ㅠ)
1. gitignore에 bert 모델 추가했습니다. 여러분들은 저에게 버트 모델 받아가셔서, split2 모듈에 넣어주시면 돼요!
2. Dockerfile에 음악 분류에 필요한 transformers를 추가하였습니다. 
    -> docker compose build 필수!
3. 오디오 전처리 과정 변경에 따라, audio_holder에 json을 가지고 있어야합니다. 그래서 필드에 jsons를 추가했습니다.
4. 우선 기존 음악 분류 로직을 넣어놓은 상태입니다. 모듈은 완성해서 넣어놨지만 아직 services.py에 반영하지는 않았습니다. 추후 stt 완료되면 변경하겠습니다.
5. 음악 분류 모델 경로는 settings.py에 넣었습니다.
6. 메인 노래 분류기 로직을 넣었습니다. 기본적으로 stt가 판단한 한 문장씩 모델이 판단하게 되고, stt가 분류한 문장 단위로 0과 1을 넣습니다. 노래 광고 분류기에 판단을 시켜, 과반수로 많은 쪽에 매핑시킵니다. return은 음악 구간입니다.

# Issue Number and Link
#134 

# To Reviewers
나름 잘 정리했다고 생각하는데, 모르는 부분있으면 코드에 코멘트 다셔도 되고 편하게 진행해주세요!! 노션에 기록은 차차하도록 하겠습니다.

close #134 