### PR TITLE
feat: whole stt using whisper

### DIFF
--- a/VisualRadio/route.py
+++ b/VisualRadio/route.py
@@ -227,6 +227,8 @@ def process_audio_file(broadcast, name, date):
                 # mr 제거
                 services.remove_mr(audio_holder)
                 clean_gpu()
+                # mr 제거한 음성 대상으로 stt 돌리기
+                stt.all_stt(audio_holder)
                 # cnn 분류기 돌리기
                 services.split_cnn(broadcast, name, date, audio_holder)
                 process.set_split2()


### PR DESCRIPTION
# Motivation
분류기 전략 변경으로 인한 전체 오디오 stt 필요성

# How to
앞서 이슈에서 설명하신 audio_holder의 jsons에다가 전체 stt 결과를 넣어두도록 기능을 추가했습니다.
jsons의 형식은 이슈에서 설명하신대로 [{"time":(초단위&밀리초자유), "txt":(문자열)}, ... ] 리스트입니다.

# Issue Number and Link
#144 

# To Reviewers
늦어서 죄송해요 ㅠㅠ
+ spleeter 메모리 터져서 로컬 테스트 진행을 못 해본 점도 죄송합니다. 딱 이번만 이렇게 올리겠습니다.