### PR TITLE
refactor: extract not_ment based on stt segment

### DIFF
--- a/VisualRadio/route.py
+++ b/VisualRadio/route.py
@@ -41,6 +41,7 @@ class AudioHolderToArray:
         self.sum = []
         self.sum_mrs = [] # 5분 단위로 쪼갠 음성을 합쳐줍니다.
         self.jsons = [] # 가장 먼저 진행되는 json들을 넣어줍니다. 이 때, time 속성은 초단위!!
+        self.durations = [] # 각 음성의 길이를 whisper가 인식한대로 저장합니다. [ [이름, 시작시간, 끝시간], ...]
     
     def set_audio_info(self):
         logger.debug("[AudioHolderToArray] setting..")

--- a/VisualRadio/services.py
+++ b/VisualRadio/services.py
@@ -272,14 +272,15 @@ def split_cnn(broadcast, name, date, audio_holder):
     idx = 0 # enumerate같은 놈
     for target_section, mr in section_mr_origin_names:
         wav = sec_wav_list[idx][1]
+        name = sec_wav_list[idx][0]
         idx += 1
         
         # 멘트 split에서 넘겨주는 인자들이 바뀌었습니다. 이 외에도, 불필요한게 몇개 있어보이지만 이 부분은 추후 수정하겠습니다.
-        ment_range, content_section, not_ment = save_split(mr, audio_holder.sr, split_ment, audio_holder.jsons)
+        ment_range, content_section, not_ment = save_split(mr, name, split_ment, audio_holder)
         logger.debug(f"[split_cnn] {target_section} split ment 끝, split_music 시작")
         
         # 광고 분류할 때 있어서도, 넘겨주는 인자가 바뀌게 됩니다. 현재는 기존 분류기를 사용하고, 예은 stt 처리가 완료되면 밑에 주석처리된 것을 사용한다.
-        music_range = split_music_origin(wav, audio_holder.sr, not_ment)
+        music_range, ad_range = split_music_origin(wav, audio_holder.sr, not_ment)
         # music_range = split_music_new(audio_holder.jsons, not_ment)
         logger.debug(f"[split_cnn] {target_section} split_music 끝")
         
@@ -313,13 +314,24 @@ def split_cnn(broadcast, name, date, audio_holder):
             
             start_time = f"{int(start) // 60}:{int(start) % 60:02d}.{ms_start}"
             end_time = f"{int(end) // 60}:{int(end) % 60:02d}.{ms_end}"
-            
+            past_type = None
+            pleaseDealWith = False
             if range_list in real_ment_range:
                 item = {"start_time": str(start_time), "end_time": str(end_time), "type": 0}
+                past_type = 0
             elif range_list in music_range:
                 item = {"start_time": str(start_time), "end_time": str(end_time), "type": 1}
-            else:
+                past_type = 0
+            elif range_list in ad_range:
                 item = {"start_time": str(start_time), "end_time": str(end_time), "type": 2}
+                past_type = 0
+            else:
+                # 완전 처음 : 만약 whipser가 3초부터 시작하면, 0~3초는 그냥 멘트라고 생각.
+                if(past_type is None):
+                    item = {"start_time": str(start_time), "end_time": str(end_time), "type": 0}
+                else:
+                    item = {"start_time": str(start_time), "end_time": str(end_time), "type": past_type}
+                    
             content_section_list.append(item)
         
         ment_start_times = []

--- a/VisualRadio/split2/split2Music.py
+++ b/VisualRadio/split2/split2Music.py
@@ -55,7 +55,35 @@ class CustomBertModel(nn.Module):
         x = self.fc(x)
         return x
     
-def split_music_new(json_data, not_ment):
+def separateNotment(not_ment, json_data):
+    res = []
+    for ran in not_ment:
+        start = ran[0]
+        end = ran[1]
+        
+        json_start_time = None
+        json_past_start_time = 0
+        for item in json_data:
+            json_start_time = item['time']
+            if start <= json_start_time < end:
+                if json_past_start_time is not None and json_start_time is not None:
+                    res.append([json_past_start_time, json_start_time])
+                
+                json_past_start_time = json_start_time
+            elif json_start_time == end:
+                res.append([json_past_start_time, json_start_time])
+            else:
+                json_start_time = None
+                json_past_start_time = None
+    
+    if json_past_start_time is not None:
+        res.append([json_past_start_time, not_ment[-1][1]])
+    return res
+    
+def split_music_new(json_data, raw_not_ment):
+    
+    not_ment = separateNotment(raw_not_ment, json_data)
+    
     device = torch.device('cuda:1' if torch.cuda.is_available() else 'cpu')
 
     model_path = settings.MUSIC_MODEL_PATH
@@ -69,18 +97,23 @@ def split_music_new(json_data, not_ment):
     predictor = CustomPredictor(bert, tokenizer, device)
 
     music_list = []
+    ad_list = []
     for start, end in not_ment:
-        music_tmp_list = []
+        logger.debug(f"[{start}, {end}]")
         for item in json_data:
             json_start_time = item['time']
+            json_txt = item['txt']
             
-            if(start <= json_start_time < end):
-                output = predictor.predict(item['txt'])
-                music_tmp_list.append(output)
-        if(np.mean(music_tmp_list) < 0.5):
-            music_list.append([start, end])
-            
-    return music_list
+            if json_start_time == start:
+                output = predictor.predict(json_txt)
+                logger.debug(f"json_txt: {json_txt}")
+                if output==0:
+                    music_list.append([start, end])
+                    logger.debug("노래입니다.")
+                else:
+                    ad_list.append([start, end])
+                    logger.debug("광고입니다.")
+    return music_list, ad_list
 
 def find_quiet_time(y, sr):
   # 주어진 스펙트로그램 데이터
@@ -151,7 +184,7 @@ def is_difference_valid(x, y):
 
 def split_music_origin(y, sr, not_ment):
     music_lst = []
-
+    ad_lst = []
     for ran in not_ment:
         start = ran[0]
         end = ran[1]
@@ -160,5 +193,7 @@ def split_music_origin(y, sr, not_ment):
 
         if(find_quiet_time(seg, sr)):
             music_lst.append(ran)
-    return music_lst
+        else:
+            ad_lst.append(ran)
+    return music_lst, ad_lst
 

--- a/VisualRadio/stt.py
+++ b/VisualRadio/stt.py
@@ -231,7 +231,7 @@ def all_stt(audio_holder):
     # ▼ 각 txt의 time을 재조정(누적)하여 scripts에 추가한다.
     script = []
     cumulative_time = 0
-    for stt in stt_sorted:
+    for stt in stt_sorted: 
         for content in stt["contents"]:
             if content[0] != '':
                 time = float(content[0]) + float(cumulative_time)
@@ -240,7 +240,14 @@ def all_stt(audio_holder):
             else:
                 logger.debug(f"[check] {type(content)}")
                 logger.debug(f"[check] content[0]가 0인 경우는 뭐지? {content}")
+        tmp = []
+        tmp.append(stt["name"])
+        tmp.append(cumulative_time)
         cumulative_time += stt["duration"]
+        tmp.append(cumulative_time)
+        audio_holder.durations.append(tmp)
+    
+    
 
     # step2) rescripting (=> make a long sentence well..)
     final_script = []
@@ -262,7 +269,8 @@ def all_stt(audio_holder):
             start_flag = True
 
     audio_holder.jsons = final_script
-    logger.debug(f"[stt] 전체 stt를 audio_holder.jsons 등록했습니다.")  # 변수명 jsons 대신에 whole_stt 어때요?
+    audio_holder.jsons.append([{"time":cumulative_time, "txt": ""}])
+    logger.debug(f"[stt] 전체 stt를 audio_holder.jsons 등록했습니다.")  # 변수명 jsons 대신에 whole_stt 어때요? 하고싶은대로 하셔요
     logger.debug(f"[stt] {audio_holder.jsons}")
     return audio_holder
 
@@ -295,7 +303,7 @@ def all_stt_whisper(name, audio, sr, stt_results, device):
         if element == results['segments'][-1]: # 만약 마지막 요소인 경우 누적된 문자열을 append하고 종료한다.
             logger.debug(f"[check] {name} | {t}")
             sentences.append([t, s.strip()])
-            break;
+            break
         if len(txt) == 0:
             continue
         if start_flag:


### PR DESCRIPTION
# Motivation
기존에는 ment_range가 아닌 큰 부분들을 not_ment로 지정했지만, 이제는 stt segment가 나눈 기준으로 not_ment를 지정한다.

# How to
stt의 segment를 고려합니다. 좀더 수월하게 진행하기 위해 stt의 제일 마지막에 오디오의 길이를 나타내게 해주었습니다.

# Issue Number and Link
close #157 

# To Reviewers
아직 직접 실행해보지 않아서(로컬에서 stt에 오류가 있어 테스트가 불가능합니다) 확인해봐야합니다. 예은이와 동일하게 바로 머지하고 테스트 진행해보겠습니다.